### PR TITLE
Fix: cascade event dispatching in event bus with polling strategy

### DIFF
--- a/contrib-eventbus/src/main/java/net/mostlyoriginal/api/event/dispatcher/PollingEventDispatcher.java
+++ b/contrib-eventbus/src/main/java/net/mostlyoriginal/api/event/dispatcher/PollingEventDispatcher.java
@@ -17,10 +17,19 @@ public class PollingEventDispatcher extends FastEventDispatcher {
 	@Override
 	public void process() {
 		Object[] eventsToDispatch = eventQueue.getData();
-		
-		for (int i = 0, s = eventQueue.size(); i < s; i++) {
-			Event event = (Event) eventsToDispatch[i];
-			super.dispatch(event);
+
+		int i = 0;
+		int s = eventQueue.size();
+
+		while (i < s) {
+			for (; i < s; i++) {
+				Event event = (Event) eventsToDispatch[i];
+				super.dispatch(event);
+			}
+
+			// we may end up having more events to dispatch at this point
+			//  - some event handlers could dispatch more events
+			s = eventQueue.size();
 		}
 		
 		eventQueue.clear();

--- a/contrib-eventbus/src/main/java/net/mostlyoriginal/api/event/dispatcher/PollingPooledEventDispatcher.java
+++ b/contrib-eventbus/src/main/java/net/mostlyoriginal/api/event/dispatcher/PollingPooledEventDispatcher.java
@@ -17,14 +17,22 @@ public class PollingPooledEventDispatcher extends FastEventDispatcher {
 	@Override
 	public void process() {
 		Object[] eventsToDispatch = eventQueue.getData();
-		
-		for (int i = 0, s = eventQueue.size(); i < s; i++) {
-			Event event = (Event) eventsToDispatch[i];
 
-			super.dispatch(event);
-			pools.free(event);
+		int i = 0;
+		int s = eventQueue.size();
+
+		while (i < s) {
+			for (; i < s; i++) {
+				Event event = (Event) eventsToDispatch[i];
+				super.dispatch(event);
+				pools.free(event);
+			}
+
+			// we may end up having more events to dispatch at this point
+			//  - some event handlers could dispatch more events
+			s = eventQueue.size();
 		}
-		
+
 		eventQueue.clear();
 	}
 

--- a/contrib-eventbus/src/test/java/net/mostlyoriginal/api/event/dispatcher/PollingEventDispatcherTest.java
+++ b/contrib-eventbus/src/test/java/net/mostlyoriginal/api/event/dispatcher/PollingEventDispatcherTest.java
@@ -4,6 +4,9 @@ import net.mostlyoriginal.api.event.common.Event;
 import net.mostlyoriginal.api.event.common.EventDispatchStrategy;
 
 public class PollingEventDispatcherTest extends AbstractEventDispatcherTest {
+	private boolean isProcessing = false;
+
+
 	@Override
 	protected EventDispatchStrategy createDispatcherInstance() {
 		return new PollingEventDispatcher();
@@ -14,8 +17,14 @@ public class PollingEventDispatcherTest extends AbstractEventDispatcherTest {
 	protected void dispatch(Event event) {
 		try {
 			dispatcher.dispatch(event);
+
 			// this dispatcher processes after a world tick.
-			dispatcher.process();
+			if (!isProcessing) {
+				// prevent call of process() in subsequent event
+				isProcessing = true;
+				dispatcher.process();
+				isProcessing = false;
+			}
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}

--- a/contrib-eventbus/src/test/java/net/mostlyoriginal/api/event/dispatcher/PollingPooledEventDispatcherTest.java
+++ b/contrib-eventbus/src/test/java/net/mostlyoriginal/api/event/dispatcher/PollingPooledEventDispatcherTest.java
@@ -5,6 +5,9 @@ import net.mostlyoriginal.api.event.common.EventDispatchStrategy;
 import org.junit.Test;
 
 public class PollingPooledEventDispatcherTest extends AbstractEventDispatcherTest {
+	private boolean isProcessing = false;
+
+
 	@Override
 	protected EventDispatchStrategy createDispatcherInstance() {
 		return new PollingPooledEventDispatcher();
@@ -21,8 +24,14 @@ public class PollingPooledEventDispatcherTest extends AbstractEventDispatcherTes
 	protected void dispatch(Event event) {
 		try {
 			dispatcher.dispatch(event.getClass());
+
 			// this dispatcher processes after a world tick.
-			dispatcher.process();
+			if (!isProcessing) {
+				// prevent call of process() in subsequent event
+				isProcessing = true;
+				dispatcher.process();
+				isProcessing = false;
+			}
 		} catch (Exception e) {
 			throw new RuntimeException(e);
 		}


### PR DESCRIPTION
When some event handler dispatches another event - it should be properly dispatched. This is not the case with polling strategy.

This PR fixes this. Unit test (first commit) shows the problem, next commit fixes it.