### PR TITLE
deps: upgrade libgdx to 1.9.5 by fixing Animation typing

### DIFF
--- a/contrib-jam/src/main/java/net/mostlyoriginal/api/system/render/AnimRenderSystem.java
+++ b/contrib-jam/src/main/java/net/mostlyoriginal/api/system/render/AnimRenderSystem.java
@@ -6,6 +6,7 @@ package net.mostlyoriginal.api.system.render;
 
 import com.artemis.Aspect;
 import com.artemis.annotations.Wire;
+import com.badlogic.gdx.graphics.g2d.Animation;
 import com.badlogic.gdx.graphics.g2d.SpriteBatch;
 import com.badlogic.gdx.graphics.g2d.TextureRegion;
 import net.mostlyoriginal.api.component.basic.Angle;
@@ -88,7 +89,7 @@ public class AnimRenderSystem extends DeferredEntityProcessingSystem {
         // don't support backwards yet.
         if ( animation.age < 0 ) return;
 
-        final com.badlogic.gdx.graphics.g2d.Animation gdxanim = abstractAssetSystem.get(id);
+        final Animation<TextureRegion> gdxanim = (Animation<TextureRegion>) abstractAssetSystem.get(id);
         if ( gdxanim == null) return;
 
         final TextureRegion frame = gdxanim.getKeyFrame(animation.age, animation.loop);

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asm.version>4.1</asm.version> 
         <artemis-odb.version>[2.0.0,3.0.0)</artemis-odb.version>
-        <libgdx.version>[1.9.0,1.9.4]</libgdx.version>
+        <libgdx.version>[1.9.5,1.9.6]</libgdx.version>
     </properties>
 
     <scm>


### PR DESCRIPTION
it didn't compile with libgdx 1.9.5 or newer. Seems to be problematic with GWT builds (for me and here https://bitbucket.org/dermetfan/libgdx-utils/issues/18/not-compatible-with-gwt-html5-on-libgdx).

 Although, I'm not sure whether it'll work properly seeing this issue: https://github.com/libgdx/libgdx/issues/4476