### PR TITLE
Release 2.4.0 (for artemis-odb 2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Version: 2.3.0-SNAPSHOT
 
-- Targets Libgdx 1.9.9, Artemis-odb 2.2.0-SNAPSHOT, GWT 2.8.0.
+- Targets Libgdx 1.9.9, Artemis-odb 2.2.0, GWT 2.8.0.
 
 ## Version: 2.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Version: 2.3.0-SNAPSHOT
+## Version: 2.4.0
 
 - Targets Libgdx 1.9.9, Artemis-odb 2.2.0, GWT 2.8.0.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,22 @@
 # Changelog
 
-## Version: 1.2.0-SNAPSHOT
+## Version: 2.3.0-SNAPSHOT
+
+- Targets Libgdx 1.9.9, Artemis-odb 2.2.0-SNAPSHOT, GWT 2.8.0.
+
+## Version: 2.2.0
+
+- Supports LibGDX 1.9.6
+- #114 fix(eventBus): support cascade event dispatching with polling strategy
+- #115 deps: upgrade libgdx to 1.9.5 by fixing Animation typin
+- Upgraded web target to GWT 2.8.0
+- #112: Removed non-deterministic dependencies (leading to unstable builds).
+
+## Version: 2.1.0
+
+- Upgraded for Artemis-odb 2.1.0 and fluid entity support!
+
+## Version: 1.2.0
 
 - Upgraded for Artemis-odb 2.0.0, LibGDX 1.9.4
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ with all fancy features, check out these instead:
 - [playn-artemis-quickstart](https://github.com/DaanVanYperen/playn-artemis-quickstart)
 
 ### Library Versions
-Artemis-odb 3.0.0-SNAPSHOT, (Optional) LibGDX 1.9.8.
+Artemis-odb 2.2.0-SNAPSHOT, (Optional) LibGDX 1.9.9.
 
 ### License
 The primary license for this code is MIT. 
@@ -32,13 +32,13 @@ Some stubs from LibGDX are licensed under Apache 2.0.
 <dependency>
   <groupId>net.mostlyoriginal.artemis-odb</groupId>
   <artifactId>contrib-core</artifactId>
-  <version>2.2.0</version>
+  <version>2.3.0</version>
 </dependency>
 
 <dependency>
   <groupId>net.mostlyoriginal.artemis-odb</groupId>
   <artifactId>contrib-eventbus</artifactId>
-  <version>2.2.0</version>
+  <version>2.3.0</version>
 </dependency>
 ```
 
@@ -46,7 +46,7 @@ Some stubs from LibGDX are licensed under Apache 2.0.
 
 ```groovy
 dependencies { 
-    compile "net.mostlyoriginal.artemis-odb:contrib-core:2.2.0"
-    compile "net.mostlyoriginal.artemis-odb:contrib-eventbus:2.2.0"
+    compile "net.mostlyoriginal.artemis-odb:contrib-core:2.3.0"
+    compile "net.mostlyoriginal.artemis-odb:contrib-eventbus:2.3.0"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Some stubs from LibGDX are licensed under Apache 2.0.
 <dependency>
   <groupId>net.mostlyoriginal.artemis-odb</groupId>
   <artifactId>contrib-core</artifactId>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
 </dependency>
 
 <dependency>
   <groupId>net.mostlyoriginal.artemis-odb</groupId>
   <artifactId>contrib-eventbus</artifactId>
-  <version>2.3.0</version>
+  <version>2.4.0</version>
 </dependency>
 ```
 
@@ -46,7 +46,7 @@ Some stubs from LibGDX are licensed under Apache 2.0.
 
 ```groovy
 dependencies { 
-    compile "net.mostlyoriginal.artemis-odb:contrib-core:2.3.0"
-    compile "net.mostlyoriginal.artemis-odb:contrib-eventbus:2.3.0"
+    compile "net.mostlyoriginal.artemis-odb:contrib-core:2.4.0"
+    compile "net.mostlyoriginal.artemis-odb:contrib-eventbus:2.4.0"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ with all fancy features, check out these instead:
 - [playn-artemis-quickstart](https://github.com/DaanVanYperen/playn-artemis-quickstart)
 
 ### Library Versions
-Artemis-odb 2.2.0-SNAPSHOT, (Optional) LibGDX 1.9.9.
+Artemis-odb 2.2.0, (Optional) LibGDX 1.9.9.
 
 ### License
 The primary license for this code is MIT. 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ with all fancy features, check out these instead:
 - [playn-artemis-quickstart](https://github.com/DaanVanYperen/playn-artemis-quickstart)
 
 ### Library Versions
-Artemis-odb 2.2.0-SNAPSHOT, (Optional) LibGDX 1.9.8.
+Artemis-odb 3.0.0-SNAPSHOT, (Optional) LibGDX 1.9.8.
 
 ### License
 The primary license for this code is MIT. 

--- a/contrib-benchmark/pom.xml
+++ b/contrib-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-benchmark</artifactId>
     <packaging>jar</packaging>

--- a/contrib-benchmark/pom.xml
+++ b/contrib-benchmark/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
     <artifactId>contrib-benchmark</artifactId>
     <packaging>jar</packaging>

--- a/contrib-benchmark/pom.xml
+++ b/contrib-benchmark/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-benchmark</artifactId>
     <packaging>jar</packaging>

--- a/contrib-benchmark/pom.xml
+++ b/contrib-benchmark/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-benchmark</artifactId>
     <packaging>jar</packaging>

--- a/contrib-benchmark/pom.xml
+++ b/contrib-benchmark/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-benchmark</artifactId>
     <packaging>jar</packaging>

--- a/contrib-benchmark/pom.xml
+++ b/contrib-benchmark/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>contrib-benchmark</artifactId>
     <packaging>jar</packaging>

--- a/contrib-core/pom.xml
+++ b/contrib-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-core</artifactId>
     <packaging>jar</packaging>

--- a/contrib-core/pom.xml
+++ b/contrib-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-core</artifactId>
     <packaging>jar</packaging>

--- a/contrib-core/pom.xml
+++ b/contrib-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-core</artifactId>
     <packaging>jar</packaging>

--- a/contrib-core/pom.xml
+++ b/contrib-core/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
     <artifactId>contrib-core</artifactId>
     <packaging>jar</packaging>

--- a/contrib-core/pom.xml
+++ b/contrib-core/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>contrib-core</artifactId>
     <packaging>jar</packaging>

--- a/contrib-core/pom.xml
+++ b/contrib-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-core</artifactId>
     <packaging>jar</packaging>

--- a/contrib-core/src/main/java/net/mostlyoriginal/api/manager/AssetManager.java
+++ b/contrib-core/src/main/java/net/mostlyoriginal/api/manager/AssetManager.java
@@ -42,7 +42,7 @@ public abstract class AssetManager<A extends Component, B extends Component> ext
 	 * @param a Existing asset identifying component.
 	 * @param b New asset reference component to setup.
 	 */
-	protected abstract void setup(Entity entity, A a, B b);
+	protected abstract void setup(int entity, A a, B b);
 
 	@Override
 	protected void setWorld(World world) {
@@ -96,7 +96,7 @@ public abstract class AssetManager<A extends Component, B extends Component> ext
 	}
 
 	protected void create(int entityId) {
-		setup(world.getEntity(entityId), mMetadataType.get(entityId), mReferenceType.create(entityId));
+		setup(entityId, mMetadataType.get(entityId), mReferenceType.create(entityId));
 	}
 
 	protected void remove(int entityId) {

--- a/contrib-core/src/test/java/net/mostlyoriginal/api/manager/AssetManagerTest.java
+++ b/contrib-core/src/test/java/net/mostlyoriginal/api/manager/AssetManagerTest.java
@@ -35,7 +35,7 @@ public class AssetManagerTest {
 			}
 
 			@Override
-			protected void setup(Entity entity, Sound sound, SoundReference soundReference) {
+			protected void setup(int entity, Sound sound, SoundReference soundReference) {
 				Assert.assertNotNull(sound);
 				Assert.assertNotNull(soundReference);
 			}
@@ -57,7 +57,7 @@ public class AssetManagerTest {
 			}
 
 			@Override
-			protected void setup(Entity entity, Sound sound, SoundReference soundReference) {
+			protected void setup(int entity, Sound sound, SoundReference soundReference) {
 				count++;
 			}
 		}
@@ -82,7 +82,7 @@ public class AssetManagerTest {
 			}
 
 			@Override
-			protected void setup(Entity entity, Sound sound, SoundReference soundReference) {
+			protected void setup(int entity, Sound sound, SoundReference soundReference) {
 				count++;
 			}
 		}
@@ -106,7 +106,7 @@ public class AssetManagerTest {
 				super(Sound.class, SoundReference.class);
 			}
 			@Override
-			protected void setup(Entity entity, Sound sound, SoundReference soundReference) {
+			protected void setup(int entity, Sound sound, SoundReference soundReference) {
 			}
 		}
 

--- a/contrib-eventbus/pom.xml
+++ b/contrib-eventbus/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>contrib-eventbus</artifactId>
     <packaging>jar</packaging>

--- a/contrib-eventbus/pom.xml
+++ b/contrib-eventbus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-eventbus</artifactId>
     <packaging>jar</packaging>

--- a/contrib-eventbus/pom.xml
+++ b/contrib-eventbus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-eventbus</artifactId>
     <packaging>jar</packaging>

--- a/contrib-eventbus/pom.xml
+++ b/contrib-eventbus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-eventbus</artifactId>
     <packaging>jar</packaging>

--- a/contrib-eventbus/pom.xml
+++ b/contrib-eventbus/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
     <artifactId>contrib-eventbus</artifactId>
     <packaging>jar</packaging>

--- a/contrib-eventbus/pom.xml
+++ b/contrib-eventbus/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-eventbus</artifactId>
     <packaging>jar</packaging>

--- a/contrib-jam/pom.xml
+++ b/contrib-jam/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-jam</artifactId>
     <packaging>jar</packaging>

--- a/contrib-jam/pom.xml
+++ b/contrib-jam/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>contrib-jam</artifactId>
     <packaging>jar</packaging>

--- a/contrib-jam/pom.xml
+++ b/contrib-jam/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-jam</artifactId>
     <packaging>jar</packaging>
@@ -25,6 +25,11 @@
         <dependency>
             <groupId>net.mostlyoriginal.artemis-odb</groupId>
             <artifactId>contrib-plugin-operations</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>net.mostlyoriginal.artemis-odb</groupId>
+            <artifactId>contrib-plugin-query-dsl</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/contrib-jam/pom.xml
+++ b/contrib-jam/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-jam</artifactId>
     <packaging>jar</packaging>

--- a/contrib-jam/pom.xml
+++ b/contrib-jam/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
     <artifactId>contrib-jam</artifactId>
     <packaging>jar</packaging>

--- a/contrib-jam/pom.xml
+++ b/contrib-jam/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-jam</artifactId>
     <packaging>jar</packaging>
@@ -25,11 +25,6 @@
         <dependency>
             <groupId>net.mostlyoriginal.artemis-odb</groupId>
             <artifactId>contrib-plugin-operations</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.mostlyoriginal.artemis-odb</groupId>
-            <artifactId>contrib-plugin-query-dsl</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>

--- a/contrib-jam/src/main/java/net/mostlyoriginal/api/manager/FontManager.java
+++ b/contrib-jam/src/main/java/net/mostlyoriginal/api/manager/FontManager.java
@@ -22,7 +22,7 @@ public class FontManager extends AssetManager<Font, BitmapFontAsset> {
 	}
 
 	@Override
-	protected void setup(Entity entity, Font font, BitmapFontAsset bitmapFontAsset) {
+	protected void setup(int entity, Font font, BitmapFontAsset bitmapFontAsset) {
 		if (font.fontName == null ) {
 			throw new RuntimeException("FontManager: font.fontName is null.");
 		}

--- a/contrib-jam/src/main/java/net/mostlyoriginal/api/manager/GdxAnimationManager.java
+++ b/contrib-jam/src/main/java/net/mostlyoriginal/api/manager/GdxAnimationManager.java
@@ -41,7 +41,7 @@ public class GdxAnimationManager extends AssetManager<Animation, AnimationAsset>
     }
 
     @Override
-    protected void setup(Entity e, Animation anim, AnimationAsset animAsset) {
+    protected void setup(int e, Animation anim, AnimationAsset animAsset) {
         animAsset.asset = library.get(anim.id);
 
         if (animAsset.asset == null) {

--- a/contrib-jam/src/main/java/net/mostlyoriginal/api/manager/SpriteManager.java
+++ b/contrib-jam/src/main/java/net/mostlyoriginal/api/manager/SpriteManager.java
@@ -29,7 +29,7 @@ public class SpriteManager extends AssetManager<Sprite, SpriteAsset> {
     private com.badlogic.gdx.assets.AssetManager manager = new com.badlogic.gdx.assets.AssetManager();
 
     @Override
-    protected void setup(Entity e, Sprite sprite, SpriteAsset spriteAsset) {
+    protected void setup(int e, Sprite sprite, SpriteAsset spriteAsset) {
         spriteAsset.asset = new Texture(sprite.id);
 
         // set size to asset.

--- a/contrib-jam/src/main/java/net/mostlyoriginal/api/manager/TerrainManager.java
+++ b/contrib-jam/src/main/java/net/mostlyoriginal/api/manager/TerrainManager.java
@@ -32,7 +32,7 @@ public class TerrainManager extends AssetManager<Terrain, TerrainAsset> {
     }
 
     @Override
-    protected void setup(Entity e, Terrain terrain, TerrainAsset asset) {
+    protected void setup(int e, Terrain terrain, TerrainAsset asset) {
         if (terrain.id == null ) {
             throw new RuntimeException("TerrainManager: terrain.id is null.");
         }

--- a/contrib-jam/src/test/java/net/mostlyoriginal/api/component/graphics/TintTest.java
+++ b/contrib-jam/src/test/java/net/mostlyoriginal/api/component/graphics/TintTest.java
@@ -33,7 +33,7 @@ public class TintTest {
 		assertColor(tint, 0f, 0f, 0f, 1f);
 	}
 
-	protected void assertColor(Tint tint, float r, float g, float b, float a) {
+	private void assertColor(Tint tint, float r, float g, float b, float a) {
 		Assert.assertEquals(r, tint.color.r, 0.01f);
 		Assert.assertEquals(g, tint.color.g, 0.01f);
 		Assert.assertEquals(b, tint.color.b, 0.01f);

--- a/contrib-network/pom.xml
+++ b/contrib-network/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
     <artifactId>contrib-network</artifactId>
     <packaging>jar</packaging>

--- a/contrib-network/pom.xml
+++ b/contrib-network/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>contrib-network</artifactId>
     <packaging>jar</packaging>

--- a/contrib-network/pom.xml
+++ b/contrib-network/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-network</artifactId>
     <packaging>jar</packaging>

--- a/contrib-network/pom.xml
+++ b/contrib-network/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-network</artifactId>
     <packaging>jar</packaging>

--- a/contrib-network/pom.xml
+++ b/contrib-network/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-network</artifactId>
     <packaging>jar</packaging>

--- a/contrib-network/pom.xml
+++ b/contrib-network/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-network</artifactId>
     <packaging>jar</packaging>

--- a/contrib-plugin-logging-api/pom.xml
+++ b/contrib-plugin-logging-api/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-api</artifactId>

--- a/contrib-plugin-logging-api/pom.xml
+++ b/contrib-plugin-logging-api/pom.xml
@@ -10,23 +10,16 @@
         <version>3.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>contrib-plugin-query-dsl</artifactId>
-    <description>Experimental query DSL for entities.</description>
+    <artifactId>contrib-plugin-logging-api</artifactId>
+    <description>
+        Logging API to hook up logging to your systems.  See contrib-plugging-logging-libgdx for an implementation!
+    </description>
 
     <dependencies>
         <dependency>
             <groupId>net.onedaybeard.artemis</groupId>
             <artifactId>artemis-odb</artifactId>
         </dependency>
-        <dependency>
-            <groupId>net.mostlyoriginal.artemis-odb</groupId>
-            <artifactId>contrib-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
+
 </project>

--- a/contrib-plugin-logging-api/pom.xml
+++ b/contrib-plugin-logging-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-api</artifactId>

--- a/contrib-plugin-logging-api/pom.xml
+++ b/contrib-plugin-logging-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-api</artifactId>

--- a/contrib-plugin-logging-api/pom.xml
+++ b/contrib-plugin-logging-api/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-api</artifactId>

--- a/contrib-plugin-logging-api/pom.xml
+++ b/contrib-plugin-logging-api/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-api</artifactId>

--- a/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/ContribPluginLoggingApi.gwt.xml
+++ b/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/ContribPluginLoggingApi.gwt.xml
@@ -1,0 +1,3 @@
+<module rename-to="net.mostlyoriginal.ContribPluginLoggingApi">
+    <source path="api"/>
+</module>

--- a/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/api/Log.java
+++ b/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/api/Log.java
@@ -6,7 +6,7 @@ package net.mostlyoriginal.api;
  * Add this class to your system, the DI will initialize it with registered implementations.
  *
  * @author Daan van Yperen
- * @since 3.0.0
+ * @since 2.3.0
  */
 public interface Log {
     /**

--- a/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/api/Log.java
+++ b/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/api/Log.java
@@ -1,0 +1,80 @@
+package net.mostlyoriginal.api;
+
+/**
+ * Logging API.
+ * <p>
+ * Add this class to your system, the DI will initialize it with registered implementations.
+ *
+ * @author Daan van Yperen
+ * @since 3.0.0
+ */
+public interface Log {
+    /**
+     * Log an informational message.
+     * Check {@see #isInfoEnabled} before calling this method to save some cycles.
+     *
+     * @param message message to log.
+     */
+    void info(String message);
+
+    /**
+     * Log an informational formatted string.
+     * Check {@see #isInfoEnabled} before calling this method to save some cycles.
+     *
+     * @param message message to log as described in Format string syntax
+     * @param args    arguments
+     * @throws java.util.IllegalFormatException If a format string contains an illegal syntax, a format specifier that is incompatible with the given arguments, insufficient arguments given the format string, or other illegal conditions. For specification of all possible formatting errors, see the Details section of the formatter class specification.
+     */
+    void info(String message, Object... args);
+
+    /**
+     * Log an error.
+     * Check {@see #isErrorEnabled} before calling this method to save some cycles.
+     *
+     * @param message message to log.
+     */
+    void error(String message);
+
+    /**
+     * Log an error as a formatted string.
+     * Check {@see #isErrorEnabled} before calling this method to save some cycles.
+     *
+     * @param message message to log as described in Format string syntax
+     * @param args    arguments
+     * @throws java.util.IllegalFormatException If a format string contains an illegal syntax, a format specifier that is incompatible with the given arguments, insufficient arguments given the format string, or other illegal conditions. For specification of all possible formatting errors, see the Details section of the formatter class specification.
+     */
+    void error(String message, Object... args);
+
+    /**
+     * Log a debug message.
+     * Check {@see #isDebugEnabled} before calling this method to save some cycles.
+     *
+     * @param message message to log.
+     */
+    void debug(String message);
+
+    /**
+     * Log a debug message as a formatted string.
+     * Check {@see #isDebugEnabled} before calling this method to save some cycles.
+     *
+     * @param message message to log as described in Format string syntax
+     * @param args    arguments
+     * @throws java.util.IllegalFormatException If a format string contains an illegal syntax, a format specifier that is incompatible with the given arguments, insufficient arguments given the format string, or other illegal conditions. For specification of all possible formatting errors, see the Details section of the formatter class specification.
+     */
+    void debug(String message, Object... args);
+
+    /**
+     * @return {@code TRUE} when info logging is enabled.
+     */
+    boolean isInfoEnabled();
+
+    /**
+     * @return {@code TRUE} when error logging is enabled.
+     */
+    boolean isErrorEnabled();
+
+    /**
+     * @return {@code TRUE} when error logging is enabled.
+     */
+    boolean isDebugEnabled();
+}

--- a/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/api/LoggingPlugin.java
+++ b/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/api/LoggingPlugin.java
@@ -1,0 +1,42 @@
+package net.mostlyoriginal.api;
+
+import com.artemis.ArtemisPlugin;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.artemis.injection.FieldResolver;
+import com.artemis.utils.reflect.Field;
+
+/**
+ * Provides logging to systems.
+ *
+ * When writing a plugin that requires logging, don't dependOn a specific
+ * implementation, instead dependOn this LoggingPlugin so users can pick
+ * their preferred logging implementation (or roll their own).
+ *
+ * Implement this class to provide your own logging.
+ *
+ * @author Daan van Yperen
+ * @see net.mostlyoriginal.plugin.LibgdxLoggingPlugin
+ * @since 3.0.0
+ */
+public abstract class LoggingPlugin implements ArtemisPlugin {
+
+    @Override
+    public void setup(WorldConfigurationBuilder b) {
+        b.register(new FieldResolver() {
+            @Override
+            public void initialize(World world) {
+            }
+
+            @Override
+            public Object resolve(Object target, Class<?> fieldType, Field field) {
+                if (fieldType.equals(Log.class)) {
+                    return createLogger(target);
+                }
+                return null;
+            }
+        });
+    }
+
+    protected abstract Object createLogger(Object target);
+}

--- a/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/api/LoggingPlugin.java
+++ b/contrib-plugin-logging-api/src/main/java/net/mostlyoriginal/api/LoggingPlugin.java
@@ -17,7 +17,7 @@ import com.artemis.utils.reflect.Field;
  *
  * @author Daan van Yperen
  * @see net.mostlyoriginal.plugin.LibgdxLoggingPlugin
- * @since 3.0.0
+ * @since 2.3.0
  */
 public abstract class LoggingPlugin implements ArtemisPlugin {
 

--- a/contrib-plugin-logging-libgdx/pom.xml
+++ b/contrib-plugin-logging-libgdx/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.mostlyoriginal.artemis-odb</groupId>
+        <artifactId>contrib-parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>contrib-plugin-logging-libgdx</artifactId>
+    <description>
+        LibGDX logging implementation.
+        Register plugin with world, add uninitialized 'Log' field to your systems,
+        Depenendecy Injection will do the rest.
+    </description>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.mostlyoriginal.artemis-odb</groupId>
+            <artifactId>contrib-plugin-logging-api</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx</artifactId>
+            <version>${libgdx.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/contrib-plugin-logging-libgdx/pom.xml
+++ b/contrib-plugin-logging-libgdx/pom.xml
@@ -1,13 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-libgdx</artifactId>

--- a/contrib-plugin-logging-libgdx/pom.xml
+++ b/contrib-plugin-logging-libgdx/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-libgdx</artifactId>

--- a/contrib-plugin-logging-libgdx/pom.xml
+++ b/contrib-plugin-logging-libgdx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-libgdx</artifactId>

--- a/contrib-plugin-logging-libgdx/pom.xml
+++ b/contrib-plugin-logging-libgdx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-libgdx</artifactId>

--- a/contrib-plugin-logging-libgdx/pom.xml
+++ b/contrib-plugin-logging-libgdx/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-logging-libgdx</artifactId>

--- a/contrib-plugin-logging-libgdx/src/main/java/net/mostlyoriginal/ContribPluginLoggingLibgdx.gwt.xml
+++ b/contrib-plugin-logging-libgdx/src/main/java/net/mostlyoriginal/ContribPluginLoggingLibgdx.gwt.xml
@@ -1,0 +1,3 @@
+<module rename-to="net.mostlyoriginal.ContribPluginLoggingLibgdx">
+    <source path="plugin"/>
+</module>

--- a/contrib-plugin-logging-libgdx/src/main/java/net/mostlyoriginal/plugin/LibgdxLoggingPlugin.java
+++ b/contrib-plugin-logging-libgdx/src/main/java/net/mostlyoriginal/plugin/LibgdxLoggingPlugin.java
@@ -17,7 +17,7 @@ import static com.badlogic.gdx.Application.LOG_INFO;
  * 1. Add {@see net.mostlyoriginal.api.Log} to your systems for logging.
  *
  * @author Daan van Yperen
- * @since 3.0.0
+ * @since 2.3.0
  */
 public class LibgdxLoggingPlugin extends LoggingPlugin {
 

--- a/contrib-plugin-logging-libgdx/src/main/java/net/mostlyoriginal/plugin/LibgdxLoggingPlugin.java
+++ b/contrib-plugin-logging-libgdx/src/main/java/net/mostlyoriginal/plugin/LibgdxLoggingPlugin.java
@@ -1,0 +1,83 @@
+package net.mostlyoriginal.plugin;
+
+import com.badlogic.gdx.Gdx;
+import net.mostlyoriginal.api.Log;
+import net.mostlyoriginal.api.LoggingPlugin;
+
+import java.util.logging.Level;
+
+import static com.badlogic.gdx.Application.LOG_DEBUG;
+import static com.badlogic.gdx.Application.LOG_ERROR;
+import static com.badlogic.gdx.Application.LOG_INFO;
+
+/**
+ * Provides logging via LibGDX.
+ * <p>
+ * Instructions:
+ * 1. Add {@see net.mostlyoriginal.api.Log} to your systems for logging.
+ *
+ * @author Daan van Yperen
+ * @since 3.0.0
+ */
+public class LibgdxLoggingPlugin extends LoggingPlugin {
+
+    @Override
+    protected Object createLogger(Object target) {
+        return new LibgdxLogImpl(target.getClass().getSimpleName());
+    }
+
+    private static class LibgdxLogImpl implements Log {
+
+        private final String tag;
+
+        public LibgdxLogImpl(String tag) {
+            this.tag = tag;
+        }
+
+        @Override
+        public void info(String message) {
+            Gdx.app.log(tag, message);
+        }
+
+        @Override
+        public void info(String message, Object... args) {
+            info(String.format(message, args));
+        }
+
+        @Override
+        public void error(String message) {
+            Gdx.app.log(tag, message);
+        }
+
+        @Override
+        public void error(String message, Object... args) {
+            error(String.format(message, args));
+        }
+
+        @Override
+        public void debug(String message) {
+            Gdx.app.debug(tag, message);
+        }
+
+        @Override
+        public void debug(String message, Object... args) {
+            debug(String.format(message, args));
+        }
+
+        @Override
+        public boolean isInfoEnabled() {
+            return Gdx.app.getLogLevel() <= LOG_INFO;
+        }
+
+        @Override
+        public boolean isErrorEnabled() {
+            return Gdx.app.getLogLevel() <= LOG_ERROR;
+        }
+
+        @Override
+        public boolean isDebugEnabled() {
+            return Gdx.app.getLogLevel() <= LOG_DEBUG;
+        }
+    }
+
+}

--- a/contrib-plugin-operations/pom.xml
+++ b/contrib-plugin-operations/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-operations</artifactId>

--- a/contrib-plugin-operations/pom.xml
+++ b/contrib-plugin-operations/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-operations</artifactId>

--- a/contrib-plugin-operations/pom.xml
+++ b/contrib-plugin-operations/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-operations</artifactId>

--- a/contrib-plugin-operations/pom.xml
+++ b/contrib-plugin-operations/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-operations</artifactId>

--- a/contrib-plugin-operations/pom.xml
+++ b/contrib-plugin-operations/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>contrib-plugin-operations</artifactId>

--- a/contrib-plugin-operations/pom.xml
+++ b/contrib-plugin-operations/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>contrib-plugin-operations</artifactId>

--- a/contrib-plugin-profiler/pom.xml
+++ b/contrib-plugin-profiler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.1-SNAPSHOT</version>
+        <version>2.4.0</version>
     </parent>
 
     <artifactId>contrib-plugin-profiler</artifactId>

--- a/contrib-plugin-profiler/pom.xml
+++ b/contrib-plugin-profiler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-profiler</artifactId>

--- a/contrib-plugin-profiler/pom.xml
+++ b/contrib-plugin-profiler/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.3.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-profiler</artifactId>

--- a/contrib-plugin-profiler/pom.xml
+++ b/contrib-plugin-profiler/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
 
     <artifactId>contrib-plugin-profiler</artifactId>

--- a/contrib-plugin-profiler/pom.xml
+++ b/contrib-plugin-profiler/pom.xml
@@ -5,13 +5,13 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-profiler</artifactId>
     <packaging>jar</packaging>
     <name>contrib-plugin-profiler</name>
-    <description>Daan's profiler for systems!</description>
+    <description>Lightweight profiler for systems!</description>
 
     <dependencies>
         <dependency>

--- a/contrib-plugin-profiler/pom.xml
+++ b/contrib-plugin-profiler/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>contrib-plugin-profiler</artifactId>

--- a/contrib-plugin-query-dsl/pom.xml
+++ b/contrib-plugin-query-dsl/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.mostlyoriginal.artemis-odb</groupId>
+        <artifactId>contrib-parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>contrib-plugin-query-dsl</artifactId>
+    <description>Experimental query DSL for entities.</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.onedaybeard.artemis</groupId>
+            <artifactId>artemis-odb</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.mostlyoriginal.artemis-odb</groupId>
+            <artifactId>contrib-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/contrib-plugin-query-dsl/src/main/java/net.mostlyoriginal/plugin/QueryDslPlugin.java
+++ b/contrib-plugin-query-dsl/src/main/java/net.mostlyoriginal/plugin/QueryDslPlugin.java
@@ -1,0 +1,43 @@
+package net.mostlyoriginal.plugin;
+
+import com.artemis.ArtemisPlugin;
+import com.artemis.World;
+import com.artemis.WorldConfigurationBuilder;
+import com.artemis.injection.FieldResolver;
+import com.artemis.utils.reflect.Field;
+import net.mostlyoriginal.plugin.querydsl.Query;
+
+/**
+ * Convenience plugin for finding entities with a stream like DSL.
+ * <p>
+ * Register plugin with builder and add {@see Query} as an uninitialized field to your systems to start using.
+ * <p>
+ * {@code WorldConfigurationBuilder().dependsOn(QueryDslPlugin.class); }
+ *
+ * @author Daan van Yperen
+ */
+public class QueryDslPlugin implements ArtemisPlugin {
+
+    @Override
+    public void setup(WorldConfigurationBuilder b) {
+        b.register(new QueryFieldResolver());
+    }
+
+    /**
+     * Provides new instances of query class.
+     */
+    private static class QueryFieldResolver implements FieldResolver {
+        private World world;
+
+        @Override
+        public void initialize(World world) {
+            this.world = world;
+        }
+
+        @Override
+        public Object resolve(Object target, Class<?> fieldType, Field field) {
+            if (Query.class.equals(fieldType)) return new Query(world);
+            return null;
+        }
+    }
+}

--- a/contrib-plugin-query-dsl/src/main/java/net.mostlyoriginal/plugin/querydsl/Query.java
+++ b/contrib-plugin-query-dsl/src/main/java/net.mostlyoriginal/plugin/querydsl/Query.java
@@ -1,0 +1,72 @@
+package net.mostlyoriginal.plugin.querydsl;
+
+import com.artemis.Aspect;
+import com.artemis.Component;
+import com.artemis.World;
+import com.artemis.annotations.UnstableApi;
+import com.artemis.managers.TagManager;
+import com.artemis.utils.IntBag;
+import net.mostlyoriginal.api.utils.Preconditions;
+
+/**
+ * Ability to query a world for entities matching a certain predicate.
+ *
+ * @author Daan van Yperen
+ * @see net.mostlyoriginal.plugin.QueryDslPlugin for registering.
+ */
+@UnstableApi
+public class Query {
+    private final World world;
+    private final TagManager tagManager;
+
+    public Query(World world) {
+        this.world = Preconditions.checkNotNull(world);
+        this.tagManager = world.getSystem(TagManager.class);
+    }
+
+    /**
+     * Get entity by tag.
+     *
+     * @return entity identifier, or {@code -1} if no such tag.
+     */
+    public int withTag(String tag) {
+        Preconditions.checkNotNull(tagManager, "Make sure tagmanager is registered in your world.");
+        return tagManager.getEntityId(tag);
+    }
+
+    /**
+     * Get all entities matching aspect.
+     * @return {@code IntBag} of entities matching aspect. Returns empty bag if no entities match aspect. */
+    public Builder withAspect(Aspect.Builder aspect) {
+        return new Builder(world.getAspectSubscriptionManager().get(aspect).getEntities());
+    }
+
+    /**
+     * Get all entities with component.
+     * This is a relatively costly operation. For performance use withAspect instead.
+     *
+     * @return {@code IntBag} of entities matching aspect. Returns empty bag if no entities match aspect.
+     */
+    public IntBag withComponent(Class<? extends Component> component) {
+        return world.getAspectSubscriptionManager().get(Aspect.all(component)).getEntities();
+    }
+
+    public static class Builder {
+        private final IntBag source;
+
+        public Builder(IntBag source) {
+            this.source = source;
+        }
+
+        /**
+         * @return Return first element.
+         */
+        public int first() {
+            return this.source.get(0);
+        }
+
+        public IntBag all() {
+            return this.source;
+        }
+    }
+}

--- a/contrib-plugin-query-dsl/src/test/java/net/mostlyoriginal/plugin/querydsl/QueryTest.java
+++ b/contrib-plugin-query-dsl/src/test/java/net/mostlyoriginal/plugin/querydsl/QueryTest.java
@@ -1,0 +1,71 @@
+package net.mostlyoriginal.plugin.querydsl;
+
+import com.artemis.*;
+import com.artemis.annotations.UnstableApi;
+import com.artemis.managers.TagManager;
+import net.mostlyoriginal.plugin.QueryDslPlugin;
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Daan van Yperen
+ */
+@UnstableApi
+public class QueryTest {
+
+    // @todo perhaps move to Generic query Query<Entity> and have each query contain one bag (or iterator).
+
+    private final Aspect.Builder TC1_ASPECT = Aspect.all(TC1.class);
+
+    ;
+
+    @Test
+    public void Should_be_able_to_find_entity_by_tag() {
+        final TagManager tagManager = new TagManager();
+        final World world = new World(new WorldConfigurationBuilder()
+                .dependsOn(QueryDslPlugin.class)
+                .with(tagManager)
+                .build());
+        final int e1 = world.create();
+
+        tagManager.register("test", e1);
+
+        Assert.assertEquals(e1, new Query(world).withTag("test"));
+    }
+
+    @Test
+    public void Should_be_able_to_find_first_entity_matching_aspect() {
+        final TagManager tagManager = new TagManager();
+        final World world = new World(new WorldConfigurationBuilder()
+                .dependsOn(QueryDslPlugin.class)
+                .with(tagManager)
+                .build());
+        final Entity e1 = world.createEntity();
+        e1.edit().add(new TC1());
+        final Entity e2 = world.createEntity();
+        e2.edit().add(new TC1());
+        final Entity e3 = world.createEntity();
+        e3.edit().add(new TC1());
+
+        Assert.assertEquals(e1.getId(), new Query(world).withAspect(TC1_ASPECT).first());
+    }
+
+
+    @Test
+    public void Should_be_able_to_find_all_entities_matching_aspect() {
+        final TagManager tagManager = new TagManager();
+        final World world = new World(new WorldConfigurationBuilder()
+                .dependsOn(QueryDslPlugin.class)
+                .with(tagManager)
+                .build());
+        final Entity e1 = world.createEntity();
+        e1.edit().add(new TC1());
+        final Entity e2 = world.createEntity();
+        e2.edit().add(new TC1());
+        final Entity e3 = world.createEntity();
+        e3.edit().add(new TC1());
+
+        Assert.assertEquals(3, new Query(world).withAspect(TC1_ASPECT).all().size());
+    }
+
+}

--- a/contrib-plugin-query-dsl/src/test/java/net/mostlyoriginal/plugin/querydsl/TC1.java
+++ b/contrib-plugin-query-dsl/src/test/java/net/mostlyoriginal/plugin/querydsl/TC1.java
@@ -1,0 +1,11 @@
+package net.mostlyoriginal.plugin.querydsl;
+
+import com.artemis.Component;
+
+/**
+ * @author Daan van Yperen
+ */
+public class TC1 extends Component {
+    public TC1() {
+    }
+}

--- a/contrib-test-gwt/pom.xml
+++ b/contrib-test-gwt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>3.0.0-SNAPSHOT</version>
+        <version>2.3.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-test-gwt</artifactId>
     <packaging>war</packaging>

--- a/contrib-test-gwt/pom.xml
+++ b/contrib-test-gwt/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0-SNAPSHOT</version>
+        <version>3.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-test-gwt</artifactId>
     <packaging>war</packaging>
@@ -47,6 +47,26 @@
         </dependency>
 
         <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx</artifactId>
+            <version>${libgdx.version}</version>
+            <classifier>sources</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-backend-gwt</artifactId>
+            <version>${libgdx.version}</version>
+            <classifier>sources</classifier>
+        </dependency>
+
+        <dependency>
+            <groupId>com.badlogicgames.gdx</groupId>
+            <artifactId>gdx-backend-gwt</artifactId>
+            <version>${libgdx.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>net.mostlyoriginal.artemis-odb</groupId>
             <artifactId>contrib-eventbus</artifactId>
             <version>${project.version}</version>
@@ -70,13 +90,13 @@
             <artifactId>artemis-odb</artifactId>
         </dependency>
 
-        <!-- Explicitly include GWT 2.8.0 -->
+        <!-- Explicitly include GWT -->
         <dependency>
             <groupId>com.google.gwt</groupId>
             <artifactId>gwt-user</artifactId>
             <version>2.8.0</version>
         </dependency>
-        <!-- / Explicitly include GWT 2.8.0 -->
+        <!-- / Explicitly include GWT -->
 
         <!-- Support for artemis-odb -->
         <dependency>

--- a/contrib-test-gwt/pom.xml
+++ b/contrib-test-gwt/pom.xml
@@ -1,11 +1,10 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0-SNAPSHOT</version>
+        <version>2.3.0</version>
     </parent>
     <artifactId>contrib-test-gwt</artifactId>
     <packaging>war</packaging>

--- a/contrib-test-gwt/pom.xml
+++ b/contrib-test-gwt/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.3.0</version>
+        <version>2.4.0</version>
     </parent>
     <artifactId>contrib-test-gwt</artifactId>
     <packaging>war</packaging>

--- a/contrib-test-gwt/pom.xml
+++ b/contrib-test-gwt/pom.xml
@@ -4,9 +4,10 @@
     <parent>
         <groupId>net.mostlyoriginal.artemis-odb</groupId>
         <artifactId>contrib-parent</artifactId>
-        <version>2.4.0</version>
+        <version>2.4.1-SNAPSHOT</version>
     </parent>
     <artifactId>contrib-test-gwt</artifactId>
+  <version>2.3.0</version>
     <packaging>war</packaging>
     <name>contrib-test-gwt</name>
     <description>Test contrib functionality under gwt.</description>
@@ -21,28 +22,28 @@
         <dependency>
             <groupId>net.mostlyoriginal.artemis-odb</groupId>
             <artifactId>contrib-core</artifactId>
-            <version>${project.version}</version>
+            <version>2.4.1-SNAPSHOT</version>
             <classifier>sources</classifier>
         </dependency>
 
         <dependency>
             <groupId>net.mostlyoriginal.artemis-odb</groupId>
             <artifactId>contrib-jam</artifactId>
-            <version>${project.version}</version>
+            <version>2.4.1-SNAPSHOT</version>
             <classifier>sources</classifier>
         </dependency>
 
         <dependency>
             <groupId>net.mostlyoriginal.artemis-odb</groupId>
             <artifactId>contrib-eventbus</artifactId>
-            <version>${project.version}</version>
+            <version>2.4.1-SNAPSHOT</version>
             <classifier>sources</classifier>
         </dependency>
 
         <dependency>
             <groupId>net.mostlyoriginal.artemis-odb</groupId>
             <artifactId>contrib-jam</artifactId>
-            <version>${project.version}</version>
+            <version>2.4.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>
@@ -68,7 +69,7 @@
         <dependency>
             <groupId>net.mostlyoriginal.artemis-odb</groupId>
             <artifactId>contrib-eventbus</artifactId>
-            <version>${project.version}</version>
+            <version>2.4.1-SNAPSHOT</version>
         </dependency>
 
         <dependency>

--- a/contrib-test-gwt/src/main/java/net/mostlyoriginal/ContribTest.gwt.xml
+++ b/contrib-test-gwt/src/main/java/net/mostlyoriginal/ContribTest.gwt.xml
@@ -3,6 +3,7 @@
     <inherits name="com.google.gwt.user.User"/>
     <inherits name="com.google.gwt.junit.JUnit"/>
     <inherits name='com.artemis.backends.artemis_backends_gwt'/>
+    <inherits name='com.badlogic.gdx.backends.gdx_backends_gwt'/>
     <inherits name="net.mostlyoriginal.ContribJam"/>
     <inherits name="net.mostlyoriginal.ContribEventBus"/>
 
@@ -10,5 +11,6 @@
 
     <extend-configuration-property name="artemis.reflect.include" value="net.mostlyoriginal.gwt.system"/>
 
+    <set-configuration-property name='xsiframe.failIfScriptTag' value='FALSE'/>
     <entry-point class='net.mostlyoriginal.gwt.ContribTest'/>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.mostlyoriginal.artemis-odb</groupId>
     <artifactId>contrib-parent</artifactId>
-    <version>2.4.0</version>
+    <version>2.4.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>contrib-parent</name>
     <description>Drop-in extensions for artemis-odb. Prefab systems, components, networking, events!
@@ -22,7 +22,7 @@
         <url>https://github.com/DaanVanYperen/artemis-odb-contrib</url>
         <connection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</connection>
         <developerConnection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</developerConnection>
-        <tag>artemis-odb-contrib-2.4.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>net.mostlyoriginal.artemis-odb</groupId>
     <artifactId>contrib-parent</artifactId>
-    <version>2.3.1-SNAPSHOT</version>
+    <version>2.4.0</version>
     <packaging>pom</packaging>
     <name>contrib-parent</name>
     <description>Drop-in extensions for artemis-odb. Prefab systems, components, networking, events!
@@ -22,7 +22,7 @@
         <url>https://github.com/DaanVanYperen/artemis-odb-contrib</url>
         <connection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</connection>
         <developerConnection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>artemis-odb-contrib-2.4.0</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.mostlyoriginal.artemis-odb</groupId>
     <artifactId>contrib-parent</artifactId>
-    <version>2.3.0-SNAPSHOT</version>
+    <version>2.3.0</version>
     <packaging>pom</packaging>
     <name>contrib-parent</name>
     <description>Drop-in extensions for artemis-odb. Prefab systems, components, networking, events!
@@ -23,7 +22,8 @@
         <url>https://github.com/DaanVanYperen/artemis-odb-contrib</url>
         <connection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</connection>
         <developerConnection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</developerConnection>
-    </scm>
+      <tag>artemis-odb-contrib-2.3.0</tag>
+  </scm>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <asm.version>4.1</asm.version> 
+        <asm.version>4.1</asm.version>
         <artemis-odb.version>2.2.0</artemis-odb.version>
         <libgdx.version>1.9.9</libgdx.version>
     </properties>
@@ -47,10 +47,10 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-              <groupId>org.mockito</groupId>
-              <artifactId>mockito-all</artifactId>
-              <version>1.9.5</version>
-              <scope>test</scope>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-all</artifactId>
+                <version>1.9.5</version>
+                <scope>test</scope>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -196,7 +196,7 @@
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
-                                 <phase>verify</phase>
+                                <phase>verify</phase>
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
@@ -212,15 +212,28 @@
 
         <plugins>
             <plugin>
-              <groupId>org.sonatype.plugins</groupId>
-              <artifactId>nexus-staging-maven-plugin</artifactId>
-              <version>1.6.2</version>
-              <extensions>true</extensions>
-              <configuration>
-                <serverId>ossrh</serverId>
-                <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                <autoReleaseAfterClose>true</autoReleaseAfterClose>
-              </configuration>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>2.5.2</version>
+                <configuration>
+                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <useReleaseProfile>false</useReleaseProfile>
+                    <releaseProfiles>release</releaseProfiles>
+                    <goals>deploy</goals>
+                    <tagNameFormat>artemis-odb-contrib-@{project.version}</tagNameFormat>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.2</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
             </plugin>
 
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>net.mostlyoriginal.artemis-odb</groupId>
     <artifactId>contrib-parent</artifactId>
-    <version>2.4.0-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>contrib-parent</name>
     <description>Drop-in extensions for artemis-odb. Prefab systems, components, networking, events!
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asm.version>4.1</asm.version> 
-        <artemis-odb.version>2.2.0-SNAPSHOT</artemis-odb.version>
+        <artemis-odb.version>3.0.0-SNAPSHOT</artemis-odb.version>
         <libgdx.version>1.9.8</libgdx.version>
     </properties>
 
@@ -109,6 +109,7 @@
         <module>contrib-core</module>
         <module>contrib-plugin-profiler</module>
         <module>contrib-plugin-operations</module>
+        <module>contrib-plugin-query-dsl</module>
         <module>contrib-jam</module>
         <module>contrib-eventbus</module>
         <module>contrib-test-gwt</module>

--- a/pom.xml
+++ b/pom.xml
@@ -109,10 +109,12 @@
         <module>contrib-core</module>
         <module>contrib-plugin-profiler</module>
         <module>contrib-plugin-operations</module>
-        <module>contrib-plugin-query-dsl</module>
+        <module>contrib-plugin-tiledmap</module>
+        <module>contrib-plugin-logging-api</module>
+        <module>contrib-plugin-logging-libgdx</module>
         <module>contrib-jam</module>
         <module>contrib-eventbus</module>
-        <module>contrib-test-gwt</module>
+        <!--<module>contrib-test-gwt</module>-->
         <module>contrib-benchmark</module>
         <module>contrib-network</module>
     </modules>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.mostlyoriginal.artemis-odb</groupId>
@@ -16,15 +17,14 @@
         <asm.version>4.1</asm.version>
         <artemis-odb.version>2.2.0</artemis-odb.version>
         <libgdx.version>1.9.9</libgdx.version>
-        <project.scm.id>git</project.scm.id>
     </properties>
 
     <scm>
         <url>https://github.com/DaanVanYperen/artemis-odb-contrib</url>
         <connection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</connection>
         <developerConnection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</developerConnection>
-      <tag>artemis-odb-contrib-2.3.0</tag>
-  </scm>
+        <tag>artemis-odb-contrib-2.3.0</tag>
+    </scm>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asm.version>4.1</asm.version> 
-        <artemis-odb.version>2.2.0-SNAPSHOT</artemis-odb.version>
+        <artemis-odb.version>2.2.0</artemis-odb.version>
         <libgdx.version>1.9.9</libgdx.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
         <asm.version>4.1</asm.version>
         <artemis-odb.version>2.2.0</artemis-odb.version>
         <libgdx.version>1.9.9</libgdx.version>
+        <project.scm.id>git</project.scm.id>
     </properties>
 
     <scm>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>net.mostlyoriginal.artemis-odb</groupId>
     <artifactId>contrib-parent</artifactId>
-    <version>3.0.0-SNAPSHOT</version>
+    <version>2.3.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>contrib-parent</name>
     <description>Drop-in extensions for artemis-odb. Prefab systems, components, networking, events!
@@ -15,8 +15,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <asm.version>4.1</asm.version> 
-        <artemis-odb.version>3.0.0-SNAPSHOT</artemis-odb.version>
-        <libgdx.version>1.9.8</libgdx.version>
+        <artemis-odb.version>2.2.0-SNAPSHOT</artemis-odb.version>
+        <libgdx.version>1.9.9</libgdx.version>
     </properties>
 
     <scm>
@@ -109,7 +109,6 @@
         <module>contrib-core</module>
         <module>contrib-plugin-profiler</module>
         <module>contrib-plugin-operations</module>
-        <module>contrib-plugin-tiledmap</module>
         <module>contrib-plugin-logging-api</module>
         <module>contrib-plugin-logging-libgdx</module>
         <module>contrib-jam</module>

--- a/pom.xml
+++ b/pom.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>net.mostlyoriginal.artemis-odb</groupId>
     <artifactId>contrib-parent</artifactId>
-    <version>2.3.0</version>
+    <version>2.3.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>contrib-parent</name>
     <description>Drop-in extensions for artemis-odb. Prefab systems, components, networking, events!
@@ -23,7 +22,7 @@
         <url>https://github.com/DaanVanYperen/artemis-odb-contrib</url>
         <connection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</connection>
         <developerConnection>scm:git:git@github.com:DaanVanYperen/artemis-odb-contrib.git</developerConnection>
-        <tag>artemis-odb-contrib-2.3.0</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <licenses>


### PR DESCRIPTION
Can be merged and released after https://github.com/junkdog/artemis-odb/pull/552

**BREAKING CHANGES**
- Requires artemis-odb 2.2.0-SNAPSHOT.
- Requires libgdx 1.9.9 (GWT 2.8.0).

**OTHER**
 
- #119 Add Shareable logging API and example logging implementation (libGDX).
- **Fix** #118: AssetManager still uses Entity.
