### PR TITLE
Fix ClassCastException when @Singleton fields don't extend Component

### DIFF
--- a/contrib-plugin-singleton/pom.xml
+++ b/contrib-plugin-singleton/pom.xml
@@ -19,6 +19,11 @@
             <groupId>net.onedaybeard.artemis</groupId>
             <artifactId>artemis-odb</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/contrib-plugin-singleton/src/main/java/net/mostlyoriginal/api/Singleton.java
+++ b/contrib-plugin-singleton/src/main/java/net/mostlyoriginal/api/Singleton.java
@@ -1,5 +1,6 @@
 package net.mostlyoriginal.api;
 
+import com.artemis.Component;
 import com.artemis.annotations.UnstableApi;
 
 import java.lang.annotation.ElementType;
@@ -8,7 +9,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Marks component as a singleton.
+ * Marks component as a singleton. Annotated classes must extend {@link Component}.
  *
  * SingletonPlugin will inject singleton dependencies into systems, handling singleton lifecycle.
  *

--- a/contrib-plugin-singleton/src/main/java/net/mostlyoriginal/api/SingletonPlugin.java
+++ b/contrib-plugin-singleton/src/main/java/net/mostlyoriginal/api/SingletonPlugin.java
@@ -3,6 +3,7 @@ package net.mostlyoriginal.api;
 import com.artemis.*;
 import com.artemis.annotations.UnstableApi;
 import com.artemis.injection.FieldResolver;
+import com.artemis.utils.reflect.ClassReflection;
 import com.artemis.utils.reflect.Field;
 
 import java.util.HashMap;
@@ -42,7 +43,7 @@ public class SingletonPlugin implements ArtemisPlugin {
 
         @Override
         public Object resolve(Object target, Class<?> fieldType, Field field) {
-            if (isAnnotationPresent(fieldType, Singleton.class) && Component.class.isAssignableFrom(fieldType)) {
+            if (isAnnotationPresent(fieldType, Singleton.class) && ClassReflection.isAssignableFrom(Component.class, fieldType)) {
                 return getCreateSingletonComponent((Class<Component>) fieldType);
             }
             return null;

--- a/contrib-plugin-singleton/src/main/java/net/mostlyoriginal/api/SingletonPlugin.java
+++ b/contrib-plugin-singleton/src/main/java/net/mostlyoriginal/api/SingletonPlugin.java
@@ -30,7 +30,7 @@ public class SingletonPlugin implements ArtemisPlugin {
      */
     public static class SingletonFieldResolver implements FieldResolver {
 
-        private HashMap<Class<?>, Component> cachedSingletons;
+        private HashMap<Class<? extends Component>, Component> cachedSingletons;
         private EntityEdit singletonContainerEntity;
 
         @Override
@@ -42,7 +42,7 @@ public class SingletonPlugin implements ArtemisPlugin {
 
         @Override
         public Object resolve(Object target, Class<?> fieldType, Field field) {
-            if (isAnnotationPresent(fieldType, Singleton.class)) {
+            if (isAnnotationPresent(fieldType, Singleton.class) && Component.class.isAssignableFrom(fieldType)) {
                 return getCreateSingletonComponent((Class<Component>) fieldType);
             }
             return null;

--- a/contrib-plugin-singleton/src/test/java/net/mostlyoriginal/api/SingletonPluginTest.java
+++ b/contrib-plugin-singleton/src/test/java/net/mostlyoriginal/api/SingletonPluginTest.java
@@ -1,0 +1,72 @@
+package net.mostlyoriginal.api;
+
+import org.junit.Test;
+
+import com.artemis.BaseSystem;
+import com.artemis.Component;
+import com.artemis.World;
+import com.artemis.WorldConfiguration;
+import com.artemis.WorldConfigurationBuilder;
+
+@SuppressWarnings("unused")
+public class SingletonPluginTest {
+
+    @Test(expected = Test.None.class)
+    public void testNonComponentSingleton() {
+        WorldConfiguration config = new WorldConfigurationBuilder()
+                .with(new SingletonPlugin())
+                .with(new NoComponentSystem())
+                .build();
+
+        new World(config);
+    }
+
+    @Test(expected = Test.None.class)
+    public void testComponentSingleton() {
+        WorldConfiguration config = new WorldConfigurationBuilder()
+                .with(new SingletonPlugin())
+                .with(new SomeComponentSystem())
+                .build();
+
+        new World(config);
+    }
+
+    public static class SomeComponentSystem extends BaseSystem {
+        private SomeComponent someComponent;
+        
+        @Override
+        protected void initialize() {
+            if (someComponent == null) {
+                throw new IllegalStateException("singleton not injected");
+            }
+        }
+
+        @Override
+        protected void processSystem() {
+        }
+    }
+
+    public static class NoComponentSystem extends BaseSystem {
+        private NoComponent noComponent;
+        
+        @Override
+        protected void initialize() {
+            if (noComponent != null) {
+                throw new IllegalStateException("non-component singleton unexpectedly injected");
+            }
+        }
+
+        @Override
+        protected void processSystem() {
+        }
+    }
+
+    @Singleton
+    public static class SomeComponent extends Component {
+    }
+
+    @Singleton
+    public static class NoComponent {
+    }
+
+}


### PR DESCRIPTION
Fixes a ClassCastException when annotated classes don't extend Component.
I also added a couple tests. Haven't used JUnit 4 in a long time though.

Got another feature in my fork, adding a [strict mode for the SingletonPlugin](https://github.com/schosin/artemis-odb-contrib/blob/feature_strict_singleton/contrib-plugin-singleton/src/main/java/net/mostlyoriginal/api/SingletonPlugin.java), which throws an exception when an entity enters the world with a singleton component added to it. I can create a PR if you're interested.