### PR TITLE
Fix querying QuadTree on borders of regions

### DIFF
--- a/contrib-core/src/main/java/net/mostlyoriginal/api/utils/QuadTree.java
+++ b/contrib-core/src/main/java/net/mostlyoriginal/api/utils/QuadTree.java
@@ -341,7 +341,7 @@ public class QuadTree implements Poolable {
         }
 
         public boolean overlaps(float x, float y, float width, float height) {
-            return this.x < x + width && this.x + this.width > x && this.y < y + height && this.y + this.height > y;
+            return this.x < x + width && this.x + this.width >= x && this.y < y + height && this.y + this.height >= y;
         }
 
         public boolean contains(float ox, float oy, float owidth, float oheight) {

--- a/contrib-core/src/test/java/net/mostlyoriginal/api/utils/quadtree/QuadTreeTest.java
+++ b/contrib-core/src/test/java/net/mostlyoriginal/api/utils/quadtree/QuadTreeTest.java
@@ -146,4 +146,67 @@ public class QuadTreeTest {
         tree.insert(8, -4, -4, 2, 2); // fully inside
 
     }
+    
+    @Test
+    public void inexact_point_single_entity_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.get(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+        
+        tree.insert(1, -1, -1, 2, 2);
+        
+        fill.clear();
+        tree.get(fill, 0, 0);
+        Assert.assertEquals(fill.size(), 1);
+    }
+
+    @Test
+    public void inexact_point_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.get(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        tree.insert(1, -1, -1, 2, 2);
+        tree.insert(2, -1, -1, 2, 2);
+
+        fill.clear();
+        tree.get(fill, 0, 0);
+        Assert.assertEquals(fill.size(), 2);
+    }
+
+    @Test
+    public void exact_point_single_entity_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.get(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        tree.insert(1, -1, -1, 2, 2);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0);
+        Assert.assertEquals(fill.size(), 1);
+    }
+
+    @Test
+    public void exact_point_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.get(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        tree.insert(1, -1, -1, 2, 2);
+        tree.insert(2, -1, -1, 2, 2);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0);
+        Assert.assertEquals(fill.size(), 2);
+    }
+
 }


### PR DESCRIPTION
This fixes the contains check of QuadTree.Container. There's an edge case, where querying points on the border of a region returns false.

As with my previous PR, I happened to run into this issue while working on another enhancement for QuadTree. See [feature_quadtree_flags](/schosin/artemis-odb-contrib/tree/feature_quadtree_flags).