### PR TITLE
Support entity flags for inserting and querying QuadTree

### DIFF
--- a/contrib-core/src/main/java/net/mostlyoriginal/api/utils/QuadTree.java
+++ b/contrib-core/src/main/java/net/mostlyoriginal/api/utils/QuadTree.java
@@ -131,7 +131,7 @@ public class QuadTree implements Poolable {
      */
     public void upsert(int eid, long flags, float x, float y, float width, float height) {
         Container c = eid < idToContainer.size() ? idToContainer.get(eid) : null;
-        if (c != null) {
+        if (c != null && c.eid != -1) {
             c.flags |= flags;
             update(eid, x, y, width, height);
             return;
@@ -431,6 +431,7 @@ public class QuadTree implements Poolable {
         if (c.parent != null) {
             c.parent.containers.remove(c);
         }
+        idToContainer.set(id, null);
         cPool.free(c);
     }
 
@@ -536,6 +537,7 @@ public class QuadTree implements Poolable {
         @Override
         public void reset() {
             eid = -1;
+            flags = 0L;
             x = 0;
             y = 0;
             width = 0;

--- a/contrib-core/src/test/java/net/mostlyoriginal/api/utils/quadtree/QuadTreeTest.java
+++ b/contrib-core/src/test/java/net/mostlyoriginal/api/utils/quadtree/QuadTreeTest.java
@@ -209,4 +209,134 @@ public class QuadTreeTest {
         Assert.assertEquals(fill.size(), 2);
     }
 
+    @Test
+    public void next_flag_test() {
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        
+        Assert.assertEquals(1L, tree.nextFlag());
+        Assert.assertEquals(2L, tree.nextFlag());
+        Assert.assertEquals(4L, tree.nextFlag());
+        Assert.assertEquals(8L, tree.nextFlag());
+    }
+
+    @Test
+    public void flags_inexact_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.get(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        tree.insert(1, 0L, -1, -1, 2, 2);
+        tree.insert(2, 1L, -1, -1, 2, 2);
+        tree.insert(3, 2L, -1, -1, 2, 2);
+        tree.insert(4, 2L, -1, -1, 2, 2);
+        tree.insert(5, 3L, -1, -1, 2, 2);
+
+        // 0 flag
+        fill.clear();
+        tree.get(fill, -2, -2, 2, 2, 0L);
+        Assert.assertEquals(fill.size(), 5);
+
+        // 1 flag
+        fill.clear();
+        tree.get(fill, -2, -2, 2, 2, 1L);
+        Assert.assertEquals(fill.size(), 2);
+
+        // 2 flag
+        fill.clear();
+        tree.get(fill, -2, -2, 2, 2, 2L);
+        Assert.assertEquals(fill.size(), 3);
+    }
+
+    @Test
+    public void flags_exact_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.getExact(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        tree.insert(1, 0L, -1, -1, 2, 2);
+        tree.insert(2, 1L, -1, -1, 2, 2);
+        tree.insert(3, 2L, -1, -1, 2, 2);
+        tree.insert(4, 2L, -1, -1, 2, 2);
+        tree.insert(5, 3L, -1, -1, 2, 2);
+
+        // 0 flag
+        fill.clear();
+        tree.getExact(fill, -2, -2, 2, 2, 0L);
+        Assert.assertEquals(fill.size(), 5);
+
+        // 1 flag
+        fill.clear();
+        tree.getExact(fill, -2, -2, 2, 2, 1L);
+        Assert.assertEquals(fill.size(), 2);
+
+        // 2 flag
+        fill.clear();
+        tree.getExact(fill, -2, -2, 2, 2, 2L);
+        Assert.assertEquals(fill.size(), 3);
+    }
+
+    @Test
+    public void flags_inexact_point_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.get(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        tree.insert(1, 0L, -1, -1, 2, 2);
+        tree.insert(2, 1L, -1, -1, 2, 2);
+        tree.insert(3, 2L, -1, -1, 2, 2);
+        tree.insert(4, 2L, -1, -1, 2, 2);
+        tree.insert(5, 3L, -1, -1, 2, 2);
+
+        // 0 flag
+        fill.clear();
+        tree.get(fill, 0, 0, 0L);
+        Assert.assertEquals(fill.size(), 5);
+
+        // 1 flag
+        fill.clear();
+        tree.get(fill, 0, 0, 1L);
+        Assert.assertEquals(fill.size(), 2);
+
+        // 2 flag
+        fill.clear();
+        tree.get(fill, 0, 0, 2L);
+        Assert.assertEquals(fill.size(), 3);
+    }
+
+    @Test
+    public void flags_exact_point_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.getExact(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        tree.insert(1, 0L, -1, -1, 2, 2);
+        tree.insert(2, 1L, -1, -1, 2, 2);
+        tree.insert(3, 2L, -1, -1, 2, 2);
+        tree.insert(4, 2L, -1, -1, 2, 2);
+        tree.insert(5, 3L, -1, -1, 2, 2);
+
+        // 0 flag
+        fill.clear();
+        tree.getExact(fill, 0, 0, 0L);
+        Assert.assertEquals(fill.size(), 5);
+
+        // 1 flag
+        fill.clear();
+        tree.getExact(fill, 0, 0, 1L);
+        Assert.assertEquals(fill.size(), 2);
+
+        // 2 flag
+        fill.clear();
+        tree.getExact(fill, 0, 0, 2L);
+        Assert.assertEquals(fill.size(), 3);
+    }
+
 }

--- a/contrib-core/src/test/java/net/mostlyoriginal/api/utils/quadtree/QuadTreeTest.java
+++ b/contrib-core/src/test/java/net/mostlyoriginal/api/utils/quadtree/QuadTreeTest.java
@@ -1,9 +1,11 @@
 package net.mostlyoriginal.api.utils.quadtree;
 
-import com.artemis.utils.IntBag;
-import net.mostlyoriginal.api.utils.QuadTree;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.artemis.utils.IntBag;
+
+import net.mostlyoriginal.api.utils.QuadTree;
 
 /**
  * Tests for {@link net.mostlyoriginal.api.utils.QuadTree}
@@ -423,6 +425,22 @@ public class QuadTreeTest {
         tree.upsert(10, 0, 0, 1, 1);
         tree.upsert(100, 0, 0, 1, 1);
         tree.upsert(1000, 0, 0, 1, 1);
+    }
+
+    @Test(expected = Test.None.class)
+    public void upsert_after_remove_inserts() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+
+        tree.upsert(0, 1L, 0, 0, 1, 1);
+        tree.remove(0);
+        tree.upsert(0, 2L, 0, 0, 1, 1);
+        
+        tree.getExact(fill, 0, 0, 1L);
+        Assert.assertEquals(fill.size(), 0);
+        
+        tree.getExact(fill, 0, 0, 2L);
+        Assert.assertEquals(fill.size(), 1);
     }
 
 }

--- a/contrib-core/src/test/java/net/mostlyoriginal/api/utils/quadtree/QuadTreeTest.java
+++ b/contrib-core/src/test/java/net/mostlyoriginal/api/utils/quadtree/QuadTreeTest.java
@@ -125,7 +125,6 @@ public class QuadTreeTest {
         Assert.assertEquals(fill.size(), 0);
     }
 
-
     @Test
     public void complex_get_test() {
         IntBag fill = new IntBag();
@@ -146,7 +145,7 @@ public class QuadTreeTest {
         tree.insert(8, -4, -4, 2, 2); // fully inside
 
     }
-    
+
     @Test
     public void inexact_point_single_entity_test() {
         IntBag fill = new IntBag();
@@ -154,9 +153,9 @@ public class QuadTreeTest {
         fill.clear();
         tree.get(fill, -2.5f, -2.5f, 5, 5);
         Assert.assertEquals(fill.size(), 0);
-        
+
         tree.insert(1, -1, -1, 2, 2);
-        
+
         fill.clear();
         tree.get(fill, 0, 0);
         Assert.assertEquals(fill.size(), 1);
@@ -212,7 +211,7 @@ public class QuadTreeTest {
     @Test
     public void next_flag_test() {
         QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
-        
+
         Assert.assertEquals(1L, tree.nextFlag());
         Assert.assertEquals(2L, tree.nextFlag());
         Assert.assertEquals(4L, tree.nextFlag());
@@ -337,6 +336,93 @@ public class QuadTreeTest {
         fill.clear();
         tree.getExact(fill, 0, 0, 2L);
         Assert.assertEquals(fill.size(), 3);
+    }
+
+    @Test
+    public void upsert_updates_position_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.getExact(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        // matching
+        tree.upsert(1, -1, -1, 2, 2);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0);
+        Assert.assertEquals(fill.size(), 1);
+
+        // not matching
+        tree.upsert(1, 1, 1, 2, 2);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0);
+        Assert.assertEquals(fill.size(), 0);
+    }
+
+    @Test
+    public void upsert_updates_flags_test() {
+        IntBag fill = new IntBag();
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+        fill.clear();
+        tree.getExact(fill, -2.5f, -2.5f, 5, 5);
+        Assert.assertEquals(fill.size(), 0);
+
+        // flag 1
+        tree.upsert(1, 1L, -1, -1, 2, 2);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 1L);
+        Assert.assertEquals(fill.size(), 1);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 2L);
+        Assert.assertEquals(fill.size(), 0);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 4L);
+        Assert.assertEquals(fill.size(), 0);
+
+        // flag 1 + 2
+        tree.upsert(1, 2L, -1, -1, 2, 2);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 1L);
+        Assert.assertEquals(fill.size(), 1);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 2L);
+        Assert.assertEquals(fill.size(), 1);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 4L);
+        Assert.assertEquals(fill.size(), 0);
+
+        // flag 1 + 2 (upserting flags 3L changes nothing)
+        tree.upsert(1, 3L, -1, -1, 2, 2);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 1L);
+        Assert.assertEquals(fill.size(), 1);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 2L);
+        Assert.assertEquals(fill.size(), 1);
+
+        fill.clear();
+        tree.getExact(fill, 0, 0, 4L);
+        Assert.assertEquals(fill.size(), 0);
+    }
+
+    @Test(expected = Test.None.class)
+    public void upsert_throws_no_exception_on_high_entity_ids() {
+        QuadTree tree = new QuadTree(-8, -8, 8, 8, 1, 8);
+
+        tree.upsert(0, 0, 0, 1, 1);
+        tree.upsert(10, 0, 0, 1, 1);
+        tree.upsert(100, 0, 0, 1, 1);
+        tree.upsert(1000, 0, 0, 1, 1);
     }
 
 }


### PR DESCRIPTION
This commit adds a couple more methods to the QuadTree, allowing for additional filtering of entities using flags to identify those a system is interested in.
Systems can add flags to entities when inserting/upserting them. Later, they can use those flags to query the QuadTree to only return entities they are interested in, removing the need to filter the results afterwards.

Using those flags to filter the QuadTree result I was able to refactor my collision system to use ~12% (majority being `QuadTree#getExact`) instead of ~80% (`QuadTree#getExact` taking up 8% of those 80%) of total time reported by VisualVM in a stress test.
Before that, I had to rely on filtering the QuadTree result using `Aspect#isInterested` and `ObjectMap#get + IntBag#contains` respectively.

As a side note: This commit also allows for multiple QuadTrees to be used in the application, since `idToContainer` is no longer a static.

**Commit message schosin/artemis-odb-contrib@18eabe3fcb0d1c97e56b3a7636a5179ed7968548:**
Support entity flags for inserting and querying QuadTree

Motivation is to use only one QuadTree, but being able to only query for
entities inserted by the call site.

An example would be a collision system where several sources for
possible collisions (e.g. unit-wall, damagingEffect-unit) could only
query the QuadTree for entities flagged by that source's flag, removing
the need for further filtering of the entities returned by the QuadTree.